### PR TITLE
add LocationType to Point

### DIFF
--- a/geocode.go
+++ b/geocode.go
@@ -35,6 +35,7 @@ type googleGeocodeResponse struct {
 				Lat float64
 				Lng float64
 			}
+			LocationType string `json:"location_type"`
 		}
 	}
 }
@@ -97,10 +98,12 @@ func (g *GoogleGeo) geocode(address, region string) (*Point, error) {
 
 	lat := res.Results[0].Geometry.Location.Lat
 	lng := res.Results[0].Geometry.Location.Lng
+	loc := res.Results[0].Geometry.LocationType
 	point := &Point{
-		Address: res.Results[0].FormattedAddress,
-		Lat:     lat,
-		Lng:     lng,
+		Address:      res.Results[0].FormattedAddress,
+		Lat:          lat,
+		Lng:          lng,
+		LocationType: loc,
 	}
 	return point, nil
 }
@@ -126,8 +129,7 @@ func (g *GoogleGeo) ReverseGeocodeDetailed(p *Point) (*GoogleReverseGeocodeRespo
 		return nil, err
 	}
 	res := &GoogleReverseGeocodeResponse{}
-	err = json.Unmarshal(data, res)
-	if err != nil {
+	if err := json.Unmarshal(data, res); err != nil {
 		return nil, err
 	}
 	if len(res.Results) == 0 {

--- a/geocode_test.go
+++ b/geocode_test.go
@@ -11,7 +11,7 @@ func ExampleGeocode() {
 	client := NewGoogleGeo("")
 	res, _ := client.Geocode("New York City")
 	fmt.Println(res)
-	// Output: &{40.7127837 -74.0059413 New York, NY, USA}
+	// Output: &{40.7127837 -74.0059413 New York, NY, USA APPROXIMATE}
 }
 
 func ExampleGeocodeWithRegion() {
@@ -20,8 +20,8 @@ func ExampleGeocodeWithRegion() {
 	fmt.Println(res)
 	res, _ = client.GeocodeWithRegion("Toledo", "es")
 	fmt.Println(res)
-	// Output: &{41.6639383 -83.55521200000001 Toledo, OH, USA}
-	// &{39.8628316 -4.027323099999999 Toledo, Spain}
+	// Output: &{41.6639383 -83.55521200000001 Toledo, OH, USA APPROXIMATE}
+	// &{39.8628316 -4.027323099999999 Toledo, Spain APPROXIMATE}
 }
 
 func ExampleReverseGeocode() {

--- a/point.go
+++ b/point.go
@@ -3,10 +3,14 @@ package geolocate
 import "math"
 
 // Point represents a Physical Point in geographic notation [lat, lng]
+// The different possible LocationTypes are documented here:
+// https://developers.google.com/maps/documentation/geocoding/intro#Results
+// It can for example be "ROOFTOP".
 type Point struct {
-	Lat     float64
-	Lng     float64
-	Address string
+	Lat          float64
+	Lng          float64
+	Address      string
+	LocationType string
 }
 
 const (


### PR DESCRIPTION
This feels a little awkward, but the only other way I could think of doing this would be:
`func (g *GoogleGeo) GeocodeAndTypeWithRegion(address, region string) (*Point, string, error) {`

Pest or kolera? :)

Fixes https://github.com/martinlindhe/google-geolocate/issues/3